### PR TITLE
chore: add reference /.well-known (ai.json, jwks, ai-crl) + schema

### DIFF
--- a/.well-known/ai-crl.json
+++ b/.well-known/ai-crl.json
@@ -1,0 +1,11 @@
+{
+  "issuer": "https://ai-manifest.org",
+  "updated_at": "2025-01-10T00:00:00Z",
+  "revoked": [
+    {
+      "kid": "2025-01-01-rsa",
+      "reason": "compromise",
+      "revoked_at": "2025-01-10T00:00:00Z"
+    }
+  ]
+}

--- a/.well-known/ai.json
+++ b/.well-known/ai.json
@@ -1,0 +1,45 @@
+{
+  "manifest_version": "0.1",
+  "provider": {
+    "name": "AI Manifest (Reference)",
+    "description": "Reference-only ai.json for examples; no production APIs.",
+    "homepage": "https://ai-manifest.org"
+  },
+  "spec": {
+    "schemas": [
+      "https://ai-manifest.org/schemas/ai-manifest-0.1.json"
+    ]
+  },
+  "servers": [
+    {
+      "type": "rest",
+      "url": "https://ai-manifest.org"
+    }
+  ],
+  "capabilities": [
+    "urn:agent:skill:ai-manifest.org:reference.v1",
+    "schemas.list"
+  ],
+  "resources": [
+    {
+      "id": "ai_schema",
+      "uri": "https://ai-manifest.org/schemas/ai-manifest-0.1.json",
+      "description": "AI Manifest v0.1 JSON Schema"
+    }
+  ],
+  "auth": {
+    "jwks_uri": "https://ai-manifest.org/.well-known/jwks.json",
+    "schemes": [
+      "none"
+    ]
+  },
+  "receipts": {
+    "signature": [
+      "JWS"
+    ]
+  },
+  "contact": {
+    "email": "agentstandards@gmail.com",
+    "url": "https://github.com/agentstandards"
+  }
+}

--- a/.well-known/jwks.json
+++ b/.well-known/jwks.json
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "kid": "2025-01-01-rsa",
+      "use": "sig",
+      "alg": "RS256",
+      "n": "base64url...",
+      "e": "AQAB"
+    }
+  ]
+}

--- a/schemas/ai-manifest-0.1.json
+++ b/schemas/ai-manifest-0.1.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ai-manifest.org/schemas/ai-manifest-0.1.json",
+  "title": "AI Manifest v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "manifest_version",
+    "provider",
+    "servers",
+    "capabilities",
+    "auth"
+  ],
+  "properties": {
+    "manifest_version": {
+      "type": "string",
+      "pattern": "^0\\.1(\\.\\d+)?$"
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "openapi_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "servers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "url"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "rest",
+              "mcp",
+              "ws",
+              "sse"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^(urn:agent:(skill|intent):[a-z0-9.-]+:[a-z0-9._-]+\\.v\\d+|[a-z0-9._:-]+)$"
+      }
+    },
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "uri"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "prompts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "content"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "input_schema": {
+            "type": "object"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "jwks_uri"
+      ],
+      "properties": {
+        "jwks_uri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "schemes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "none",
+              "http",
+              "bearer",
+              "mtls",
+              "oauth2",
+              "sig-http",
+              "jws",
+              "cose"
+            ]
+          }
+        }
+      }
+    },
+    "receipts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "signature": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "JWS",
+              "COSE",
+              "Ed25519",
+              "EIP-191"
+            ]
+          }
+        }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "policy": {
+          "type": "string",
+          "format": "uri"
+        },
+        "terms": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Reference-only /.well-known for docs and remote validation.
- ai.json (v0.1)
- jwks.json (placeholder)
- ai-crl.json (example)
- schemas/ai-manifest-0.1.json

Non-binding, for examples and tooling validation.